### PR TITLE
Add textAlignment property to SystemNotificationMessageStyle

### DIFF
--- a/Sources/SystemNotification/SystemNotificationMessage.swift
+++ b/Sources/SystemNotification/SystemNotificationMessage.swift
@@ -128,7 +128,7 @@ private extension SystemNotificationMessage {
 private extension SystemNotificationMessage {
 
     var textContent: some View {
-        VStack(spacing: style.titleTextSpacing) {
+        VStack(alignment: style.textAlignment.horizontal, spacing: style.titleTextSpacing) {
             if let title = title {
                 Text(title, bundle: bundle ?? nil)
                     .font(style.titleFont)
@@ -138,7 +138,7 @@ private extension SystemNotificationMessage {
                 .font(style.textFont)
                 .foregroundStyle(foregroundColor(for: style.textColor))
         }
-        .multilineTextAlignment(.center)
+        .multilineTextAlignment(style.textAlignment)
     }
     
     @ViewBuilder

--- a/Sources/SystemNotification/SystemNotificationMessageStyle.swift
+++ b/Sources/SystemNotification/SystemNotificationMessageStyle.swift
@@ -30,6 +30,7 @@ public struct SystemNotificationMessageStyle {
     ///   - padding: The padding to add to the content.
     ///   - textColor: The color to apply to the text.
     ///   - textFont: The font to apply to the text.
+    ///   - textAlignment: The multiline text alignment to apply to the text content.
     ///   - titleColor: The color to apply to the title.
     ///   - titleFont: The font to apply to the title.
     ///   - titleTextSpacing: The spacing to apply between the title and the text.
@@ -42,6 +43,7 @@ public struct SystemNotificationMessageStyle {
         padding: CGSize = .init(width: 15, height: 7),
         textColor: Color = .secondary,
         textFont: Font = Font.footnote.bold(),
+        textAlignment: TextAlignment = .center,
         titleColor: Color = .primary,
         titleFont: Font = Font.footnote.bold(),
         titleTextSpacing: CGFloat = 2
@@ -54,6 +56,7 @@ public struct SystemNotificationMessageStyle {
         self.padding = padding
         self.textColor = textColor
         self.textFont = textFont
+        self.textAlignment = textAlignment
         self.titleColor = titleColor
         self.titleFont = titleFont
         self.titleTextSpacing = titleTextSpacing
@@ -82,6 +85,9 @@ public struct SystemNotificationMessageStyle {
     
     /// The font to apply to the text.
     public var textFont: Font
+    
+    /// The multiline text alignment to apply to the text content.
+    public var textAlignment: TextAlignment
     
     /// The color to apply to the title.
     public var titleColor: Color
@@ -122,5 +128,17 @@ public extension EnvironmentValues {
     var systemNotificationMessageStyle: SystemNotificationMessageStyle {
         get { self [SystemNotificationMessageStyle.Key.self] }
         set { self [SystemNotificationMessageStyle.Key.self] = newValue }
+    }
+}
+
+extension TextAlignment {
+
+    /// Map ``TextAlignment`` to ``HorizontalAlignment``.
+    var horizontal: HorizontalAlignment {
+        switch self {
+        case .leading: return .leading
+        case .center: return .center
+        case .trailing: return .trailing
+        }
     }
 }


### PR DESCRIPTION

## Motivation
The text alignment in `SystemNotificationMessage` was hardcoded to `.center`,
both for VStack child alignment and `multilineTextAlignment`. This made it
impossible to create left-aligned or right-aligned notification messages via
the style system.
## Changes
- Added `textAlignment: TextAlignment` property to `SystemNotificationMessageStyle`
  (defaults to `.center` to preserve existing behavior).
- Updated `SystemNotificationMessage.textContent` to use `style.textAlignment`
  for both the `VStack` horizontal alignment and `multilineTextAlignment`.
- Added a `TextAlignment.horizontal` extension to map `TextAlignment` to
  `HorizontalAlignment` for use in VStack alignment.
## Usage
```swift
SystemNotificationMessage(
    icon: Image(systemName: "bell.slash.fill"),
    title: "Title",
    text: "A longer message that demonstrates\nmultiline text alignment."
)
.systemNotificationMessageStyle(
    .init(textAlignment: .leading)
)